### PR TITLE
address comments on WGLC(02Draft)

### DIFF
--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -533,10 +533,9 @@ responder MAY include two SingleResponses in a BasicOCSPResponse.
 In that BasicOCSPResponse,
 the CertID of one of the SingleResponses uses SHA-1 for the hash
 calculation, and the CertID in the other SingleResponse uses SHA-256.
-Once clients reliant on or relevant to a given OCSP responder have
-migrated to the profile as defined in this specification, OCSP
-responders SHALL NOT distribute OCSP responses that contain CertIDs that
-use SHA-1.
+OCSP responders SHOULD NOT distribute OCSP responses that contain
+CertIDs that use SHA-1 if the OCSP responder has no clients
+that require the use of SHA-1.
 
 # Security Considerations {#sec-cons}
 

--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -244,14 +244,13 @@ Responders MUST generate a BasicOCSPResponse as identified by the
 id-pkix-ocsp-basic OID. Clients MUST be able to parse and accept a
 BasicOCSPResponse. OCSPResponses that conform to this profile SHOULD
 include only one SingleResponse in the
-BasicOCSPResponse.ResponseData.responses structure, but MAY include
+ResponseData.responses structure, but MAY include
 additional SingleResponse elements if necessary to improve response
 pre-generation performance　or cache efficiency
 with ensuring backwardcompatibility. For instance,
 to provide support to OCSP clients which do not yet support the
 use of SHA-256 for CertID hash calculation, the OCSP responder
-MAY include two SingleResponses in a
-BasicOCSPResponse.ResponseData.responses structure.
+MAY include two SingleResponses in a BasicOCSPResponse.
 In that BasicOCSPResponse, the CertID of one of the SingleResponses
 uses SHA-1 for the hash calculation, and the CertID in the other
 SingleResponse uses SHA-256. OCSP responders SHOULD NOT distribute

--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -247,7 +247,7 @@ include only one SingleResponse in the
 ResponseData.responses structure, but MAY include
 additional SingleResponse elements if necessary to improve response
 pre-generation performance or cache efficiency
-with ensuring backwardcompatibility. For instance,
+with ensuring backward compatibility. For instance,
 to provide support to OCSP clients which do not yet support the
 use of SHA-256 for CertID hash calculation, the OCSP responder
 MAY include two SingleResponses in a BasicOCSPResponse.

--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -145,7 +145,7 @@ functionality as defined in {{RFC6960}}.
 ### OCSPRequest Structure {#certid}
 
 The ASN.1 structure corresponding to the OCSPRequest
-and relevant with CertID is:
+with the relevant CertID is:
 
 ~~~~~~
 OCSPRequest     ::=     SEQUENCE {
@@ -206,7 +206,7 @@ requestorName field were absent.
 
 ### OCSPResponse Structure
 The ASN.1 structure corresponding to the OCSPResponse
-and relevant with CertID is:
+with the relevant CertID is:
 
 ~~~~~~
 OCSPResponse ::= SEQUENCE {
@@ -246,8 +246,8 @@ BasicOCSPResponse. OCSPResponses that conform to this profile SHOULD
 include only one SingleResponse in the
 ResponseData.responses structure, but MAY include
 additional SingleResponse elements if necessary to improve response
-pre-generation performance or cache efficiency
-with ensuring backward compatibility. For instance,
+pre-generation performance or cache efficiency, and
+to ensure backward compatibility. For instance,
 to provide support to OCSP clients which do not yet support the
 use of SHA-256 for CertID hash calculation, the OCSP responder
 MAY include two SingleResponses in a BasicOCSPResponse.
@@ -256,6 +256,10 @@ uses SHA-1 for the hash calculation, and the CertID in the other
 SingleResponse uses SHA-256. OCSP responders SHOULD NOT distribute
 OCSP responses that contain CertIDs that use SHA-1 if the OCSP
 responder has no clients that require the use of SHA-1.
+Operators of OCSP responders may consider logging the hash
+algorithm used by OCSP clients to inform their determination of
+when it is appropriate to obsolete the distribution of OCSP responses
+that employ SHA-1 for CertID field hashes.
 
 The responder SHOULD NOT include responseExtensions. As specified in
 {{RFC6960}}, clients MUST ignore unrecognized non-critical
@@ -435,13 +439,16 @@ to the calling application environment. For example, Internet peers
 with low latency connections typically expect NTP time
 synchronization to keep them accurate within parts of a second;
 higher latency environments or where an NTP analogue is not available
-may have to be more liberal in their tolerance.
+may have to be more liberal in their tolerance
+(e.g. allow one day difference).
 
 See the security considerations in {{sec-cons}} for additional details
 on replay and man-in-the-middle attacks.
 
 # Transport Profile {#transport}
 
+HTTP-based OCSP requests can use either the GET or the POST method
+to submit their requests.
 The OCSP responder MUST support requests and responses over HTTP.
 When sending requests that are less than or equal to 255 bytes in
 total (after encoding) including the scheme and delimiters (http://),

--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -243,12 +243,20 @@ SingleResponse ::= SEQUENCE {
 Responders MUST generate a BasicOCSPResponse as identified by the
 id-pkix-ocsp-basic OID. Clients MUST be able to parse and accept a
 BasicOCSPResponse. OCSPResponses that conform to this profile SHOULD
-include only one SingleResponse in the ResponseData.responses
-structure, but MAY include additional SingleResponse elements if
-necessary to improve response pre-generation performance or cache
-efficiency. For instance, ResponseData.responses of OCSPResponses
-that conform to this profile MAY include two SingleResponse
-with SHA-1 and SHA-256 certID of the same certificate.
+include only one SingleResponse in the
+BasicOCSPResponse.ResponseData.responses structure, but MAY include
+additional SingleResponse elements if necessary to improve response
+pre-generation performance　or cache efficiency
+with ensuring backwardcompatibility. For instance,
+to provide support to OCSP clients which do not yet support the
+use of SHA-256 for CertID hash calculation, the OCSP responder
+MAY include two SingleResponses in a
+BasicOCSPResponse.ResponseData.responses structure.
+In that BasicOCSPResponse, the CertID of one of the SingleResponses
+uses SHA-1 for the hash calculation, and the CertID in the other
+SingleResponse uses SHA-256. OCSP responders SHOULD NOT distribute
+OCSP responses that contain CertIDs that use SHA-1 if the OCSP
+responder has no clients that require the use of SHA-1.
 
 The responder SHOULD NOT include responseExtensions. As specified in
 {{RFC6960}}, clients MUST ignore unrecognized non-critical
@@ -585,16 +593,6 @@ the certificate status request extension mechanism for TLS.
 
 Further information regarding caching issues can be obtained
 from {{?RFC3143}}.
-
-To provide support to OCSP clients which do not yet
-support the use of SHA-256 for CertID hash calculation, the OCSP
-responder MAY include two SingleResponses in a BasicOCSPResponse.
-In that BasicOCSPResponse,
-the CertID of one of the SingleResponses uses SHA-1 for the hash
-calculation, and the CertID in the other SingleResponse uses SHA-256.
-OCSP responders SHOULD NOT distribute OCSP responses that contain
-CertIDs that use SHA-1 if the OCSP responder has no clients
-that require the use of SHA-1.
 
 # Security Considerations {#sec-cons}
 

--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -144,6 +144,31 @@ functionality as defined in {{RFC6960}}.
 
 ### OCSPRequest Structure {#certid}
 
+The ASN.1 structure corresponding to the OCSPRequest
+and relevant with CertID is:
+
+~~~~~~
+OCSPRequest     ::=     SEQUENCE {
+       tbsRequest                  TBSRequest,
+       optionalSignature   [0]     EXPLICIT Signature OPTIONAL }
+
+TBSRequest      ::=     SEQUENCE {
+       version             [0]     EXPLICIT Version DEFAULT v1,
+       requestorName       [1]     EXPLICIT GeneralName OPTIONAL,
+       requestList                 SEQUENCE OF Request,
+       requestExtensions   [2]     EXPLICIT Extensions OPTIONAL }
+
+Request         ::=     SEQUENCE {
+       reqCert                     CertID,
+       singleRequestExtensions     [0] EXPLICIT Extensions OPTIONAL }
+
+CertID          ::=     SEQUENCE {
+       hashAlgorithm       AlgorithmIdentifier,
+       issuerNameHash      OCTET STRING, -- Hash of issuer's DN
+       issuerKeyHash       OCTET STRING, -- Hash of issuer's public key
+       serialNumber        CertificateSerialNumber }
+~~~~~~
+
 OCSPRequests that conform to this profile MUST include only one Request
 in the OCSPRequest.RequestList structure.
 
@@ -180,6 +205,40 @@ requestorName field were absent.
 ## OCSP Response Profile
 
 ### OCSPResponse Structure
+The ASN.1 structure corresponding to the OCSPResponse
+and relevant with CertID is:
+
+~~~~~~
+OCSPResponse ::= SEQUENCE {
+      responseStatus         OCSPResponseStatus,
+      responseBytes          [0] EXPLICIT ResponseBytes OPTIONAL }
+
+ResponseBytes ::=       SEQUENCE {
+        responseType   OBJECT IDENTIFIER,
+        response       OCTET STRING }
+
+The value for response SHALL be the DER encoding of BasicOCSPResponse.
+
+BasicOCSPResponse       ::= SEQUENCE {
+      tbsResponseData      ResponseData,
+      signatureAlgorithm   AlgorithmIdentifier,
+      signature            BIT STRING,
+      certs            [0] EXPLICIT SEQUENCE OF Certificate OPTIONAL }
+
+ResponseData ::= SEQUENCE {
+      version              [0] EXPLICIT Version DEFAULT v1,
+      responderID              ResponderID,
+      producedAt               GeneralizedTime,
+      responses                SEQUENCE OF SingleResponse,
+      responseExtensions   [1] EXPLICIT Extensions OPTIONAL }
+
+SingleResponse ::= SEQUENCE {
+      certID                       CertID,
+      certStatus                   CertStatus,
+      thisUpdate                   GeneralizedTime,
+      nextUpdate         [0]       EXPLICIT GeneralizedTime OPTIONAL,
+      singleExtensions   [1]       EXPLICIT Extensions OPTIONAL }
+~~~~~~
 
 Responders MUST generate a BasicOCSPResponse as identified by the
 id-pkix-ocsp-basic OID. Clients MUST be able to parse and accept a

--- a/draft-ietf-lamps-rfc5019bis.md
+++ b/draft-ietf-lamps-rfc5019bis.md
@@ -246,7 +246,7 @@ BasicOCSPResponse. OCSPResponses that conform to this profile SHOULD
 include only one SingleResponse in the
 ResponseData.responses structure, but MAY include
 additional SingleResponse elements if necessary to improve response
-pre-generation performance　or cache efficiency
+pre-generation performance or cache efficiency
 with ensuring backwardcompatibility. For instance,
 to provide support to OCSP clients which do not yet support the
 use of SHA-256 for CertID hash calculation, the OCSP responder


### PR DESCRIPTION
Addressed Rob’s comment with Tim, Russ comment
https://mailarchive.ietf.org/arch/msg/spasm/Bk-0_zas5PTqL-us0JDv8fyQQWQ/
- remove SHALL NOT
- move two SingleResponse sentence to profile section with explicitly mention about backward compatibility

Addressed Rich’s comment
https://mailarchive.ietf.org/arch/msg/spasm/cu1gJwy2kxHqxrjGwarA5kPs3lo/
- List the terms that come from ASN.1 of 5019/6960 
- with the fact of some environment allow a day of leeway, so add “(e.g. allow one day difference)”
- add "HTTP-based OCSP requests can use either the GET or the POST method to submit their requests."

Add possibility of logging requests to check how much SHA-1 is used for Client’s CertID, and use that information to determine when to stop SHA-1 support. 